### PR TITLE
duplicate split transactions with custom amounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## [0.1.0] - 2024-01-15
 
 - init commit :sparkles:
+
+## [0.2.0] - 2024-07-10
+
+- custom split transactions: to use this feature, split a transaction anyway you want and add the splitting flag to it

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Limitations (pull requests welcome!):
 - Budgets must be accessible by one account
 - This will not handle doing the math of who owes how much
 - Cannot handle any transactions that have already been split
-- Always splits everything 50/50
 
 ## Setup
 TODO

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,14 +105,13 @@ const duplicateTransactions = async (fromBudget: BudgetConfig, toBudget: BudgetC
 };
 
 const duplicateSplitTransaction = async (transaction: any, toBudget: BudgetConfig, fromBudget: BudgetConfig) => {
-  const splitAmount1 = transaction.subtransactions[0].amount;
-  const splitAmount2 = transaction.subtransactions[1].amount;
+  const splitAmount = transaction.subtransactions.filter((subtransaction: any) => subtransaction.category_id === fromBudget.splitCategoryId)[0].amount;
 
   const duplicatedTransaction: PostTransactionsWrapper = {
     transaction: {
       account_id: toBudget.sharedAccountId,
       date: transaction.date,
-      amount: splitAmount2,
+      amount: splitAmount,
       memo: transaction.memo,
       cleared: 'cleared',
       payee_name: transaction.payee_name,
@@ -128,7 +127,7 @@ const duplicateSplitTransaction = async (transaction: any, toBudget: BudgetConfi
 
   if (dryRun) {
     console.log(
-      `Dry run: Would be creating split 1 of transaction for the amount ${splitAmount2} to budget ${toBudget.id}`,
+      `Dry run: Would be creating split 1 of transaction for the amount ${splitAmount} to budget ${toBudget.id}`,
       `Dry run: Would update transaction in budget ${fromBudget.id} to change the flag color`,
     );
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ const duplicateSplitTransaction = async (transaction: any, toBudget: BudgetConfi
   if (!dryRun) {
     if (verbose) {
       console.log(
-        `Duplicating split 1 of transaction for the amount ${splitAmount2} to budget ${toBudget.id}`,
+        `Duplicating split 1 of transaction for the amount ${splitAmount} to budget ${toBudget.id}`,
       );
     }
 


### PR DESCRIPTION
🚧 New Feature 🚧 

Split the transaction in your budget with the **"outgoing" split first**. Also, make sure to use the correct flag (mine is red).
In this example, this transaction was split 3 ways. One share was paid over Venmo already, and now I need to charge Niko for 1 share. So I split the transaction 1/3 and 2/3.

<img width="1316" alt="Screenshot 2024-07-10 at 2 38 42 PM" src="https://github.com/user-attachments/assets/453526f1-d1ad-4af8-afe4-af9487ecce9d">

Then, I ran splitter:dry locally, which gives the right result 👍🏻
```
Found 0 transactions to split in budget bb47660d-2364-41f8-87ca-7730e2889d5f and move to budget 225d1ff4-ab34-418c-992d-280d40edacce
Found 1 transactions to split in budget 225d1ff4-ab34-418c-992d-280d40edacce and move to budget bb47660d-2364-41f8-87ca-7730e2889d5f
Found already split transaction to duplicate in budget 225d1ff4-ab34-418c-992d-280d40edacce and move to budget bb47660d-2364-41f8-87ca-7730e2889d5f
Dry run: Would be creating split 1 of transaction for the amount -18330 to budget bb47660d-2364-41f8-87ca-7730e2889d5f Dry run: Would update transaction in budget 225d1ff4-ab34-418c-992d-280d40edacce to change the flag color
```

Then, ran it for real:

✅  updates the original budget with the right flag color
<img width="1446" alt="Screenshot 2024-07-10 at 2 51 07 PM" src="https://github.com/user-attachments/assets/86416804-c9f0-4ddc-bc8c-3f0d350ca098">

✅ updates the toBudget with the new transaction in the right color & amount
<img width="1455" alt="Screenshot 2024-07-10 at 2 51 46 PM" src="https://github.com/user-attachments/assets/9c65cfd8-47a3-4219-be5b-479b32fa15ba">
